### PR TITLE
Gauge value must be converted in a float when changed

### DIFF
--- a/angular-canvas-gauge.js
+++ b/angular-canvas-gauge.js
@@ -183,7 +183,7 @@ angular.module('angular-canvas-gauge', []).directive('canvasGauge', function() {
       /* Observers for the directive attributes */
 
       attributes.$observe('value', function(value) {
-        gauge.setValue(value);
+        gauge.setValue(parseFloat(value));
       });
 
       attributes.$observe('valueFormat', function(value) {


### PR DESCRIPTION
The Gauge.value must be parsed as a float when change. If not, we can observe a funny thing when from the value 100 in the following example
```html
<body ng-app="appSampleMod" ng-controller="appSampleCtrl">
   <input type="number" ng-model="gauge.value" />
   <br/>

  <canvas canvas-gauge
   id="myCanvas"
   width="{{gauge.width}}"
   height="{{gauge.height}}"
   data-value="{{gauge.value}}"
   data-min-value="50"
   data-max-value="250"
   data-major-ticks="50 100 150 200 250"
   data-value-format="3.2"
  ></canvas>

  <script>
    angular.module('appSampleMod', ['angular-canvas-gauge'])
    .controller('appSampleCtrl', ['$scope', function($scope, $interval) {

      $scope.gauge = {
        value: 90,
        width: 300,
        height: 300
      };
    }]);
  </script>
 </body>
```